### PR TITLE
Add bind to all config

### DIFF
--- a/nio.conf
+++ b/nio.conf
@@ -402,6 +402,9 @@ publisher_min_port=9010
 #
 publisher_max_port=9199
 
+# Bind to all interfaces when launching the broker
+#broker_bind_to_all=False
+
 # matching algorithm to use for subscribers
 #
 #matching=nio.modules.communication.matching.default.DefaultMatching


### PR DESCRIPTION
This setting is used in the ZMQ communication module but does not appear in the `nio.conf`.

Setting this to true will bind the ZMQ broker to all IPs/interfaces (`tcp://*:9000` instead of `tcp://127.0.0.1:9000`). This is useful if your broker needs to be accessed via a hostname rather than an IP address (e.g., when running in docker).