### PR TITLE
default to 443 as standard

### DIFF
--- a/nio.env
+++ b/nio.env
@@ -13,20 +13,20 @@ INSTANCE_ID: local
 # Pubkeeper Client
 PK_TOKEN:
 PK_HOST:
-PK_PORT: 9898
+PK_PORT: 443
 PK_SECURE: True
 PK_CA_CHAIN:
 
 # WebsocketBrew Variables
 WS_HOST:
-WS_PORT: 80
+WS_PORT: 443
 WS_SECURE: True
 
 # Pubkeeper Server
 PKS_JWT_SECRET:
 PKS_ADDR:
 PKS_INTERFACE: lo0
-PKS_PORT: 9898
+PKS_PORT: 443
 
 # ZMQ / ZMQBrew Variables
 # your IP address that other nodes can reach you on


### PR DESCRIPTION
Unless there's a reason we aren't defaulting these to the standard secure port?