### PR TITLE
standalone off by default

### DIFF
--- a/nio.conf
+++ b/nio.conf
@@ -168,7 +168,7 @@ brews=pubkeeper.brew.local.brew.LocalBrew
 [pubkeeper_server]
 # Specifies whether this nio instance launches its own Pubkeeper Server
 #
-standalone=True
+#standalone=True
 
 # JWT Secret.  Used to validate tokens clients give to authenticate
 #

--- a/nio.conf
+++ b/nio.conf
@@ -168,7 +168,7 @@ brews=pubkeeper.brew.local.brew.LocalBrew
 [pubkeeper_server]
 # Specifies whether this nio instance launches its own Pubkeeper Server
 #
-#standalone=True
+#standalone=False
 
 # JWT Secret.  Used to validate tokens clients give to authenticate
 #


### PR DESCRIPTION
Nicer for `nio-lite` users