### PR TITLE
Make all Pubkeeper logs info level

### DIFF
--- a/etc/logging.json
+++ b/etc/logging.json
@@ -56,10 +56,7 @@
         "main.ServiceManager": {
             "level": "INFO"
         },
-        "pubkeeper.client": {
-            "level": "INFO"
-        },
-        "pubkeeper.protocol": {
+        "pubkeeper": {
             "level": "INFO"
         }
     }


### PR DESCRIPTION
This will allow us to see server logs (if running a server), brew logs, and any future PK logs that we add. I have found this setting much more useful in my local runs of nio rather than suppressing these logs.