### PR TITLE
Add instance ID and API key to default config

### DIFF
--- a/nio.conf
+++ b/nio.conf
@@ -12,6 +12,7 @@ PROJECT_ROOT=
 
 INSTANCE_NAME=local
 INSTANCE_ID=local
+API_KEY=
 
 # Pubkeeper Client
 PK_HOST=your-system-id.pubkeeper.nio.works
@@ -60,3 +61,7 @@ ssl_certificate=
 ssl_private_key=
 # optional certificate chain
 ssl_certificate_chain=
+
+[instance]
+instance_id=[[INSTANCE_ID]]
+api_key=[[API_KEY]]


### PR DESCRIPTION
We should eventually remove `local` as the instance ID default but doing so with binaries 20180910 and earlier will have some issues as it looks for that environment variable to not be blank